### PR TITLE
Ensure clipboard.js instance is destroyed when component is torndown

### DIFF
--- a/addon/components/clip-board.js
+++ b/addon/components/clip-board.js
@@ -12,6 +12,12 @@ export default Ember.Component.extend({
     'data-clipboard-action', 'data-clipboard-target', 'data-clipboard-text'
   ],
 
+  /*
+  @private
+  Internal reference to Clipboard instance
+   */
+  _clipboard: null,
+
   action: 'copy',
   target: null,
   text: null,
@@ -24,8 +30,13 @@ export default Ember.Component.extend({
     this.initializeClipboard();
   },
 
+  willDestroyElement() {
+    this.teardownClipboard();
+  },
+
   initializeClipboard() {
     const clipboard = new Clipboard(`#${this.elementId}`);
+    this.set('_clipboard', clipboard);
 
     clipboard.on('success', event => {
       this.sendAction('onSuccess', event);
@@ -34,5 +45,12 @@ export default Ember.Component.extend({
     clipboard.on('error', event => {
       this.sendAction('onError', event);
     });
+  },
+
+  teardownClipboard() {
+    const clipboard = this.get('_clipboard');
+    clipboard.off('success error');
+    clipboard.destroy();
+    this.set('_clipboard', null);
   }
 });

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "primer-css": "~2.3.3",


### PR DESCRIPTION
This simply cleans up the clipboard instances so we don't end up with
a bunch of them in memory after our components are removed from the DOM.
